### PR TITLE
Move from project.json to msbuild

### DIFF
--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -195,8 +195,8 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
     
-ENV DOTNET_SDK_VERSION 1.0.0-preview2-003156
-ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
+ENV DOTNET_SDK_VERSION 1.0.0-rc4-004771
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-dev-debian-x64.$DOTNET_SDK_VERSION.tar.gz
 
 RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
     && mkdir -p /usr/share/dotnet \
@@ -209,7 +209,7 @@ RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
 ENV NUGET_XMLDOC_MODE skip
 RUN mkdir warmup \
     && cd warmup \
-    && dotnet new \
+    && dotnet new web \
     && cd .. \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch


### PR DESCRIPTION
This change moves forward to msbuild-based .NET Core apps. It supports both 1.0 and 1.1.