### PR TITLE
Add PHP5.6, PHP7.0 and Composer

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -217,7 +217,25 @@ RUN mkdir warmup \
     && cd .. \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch
-	
+
+# PHP5.6
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends php5-cli
+
+# PHP7
+RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/stretch.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends php7.0-cli php7.0-zip \
+  && rm -f /etc/apt/sources.list.d/stretch.list
+
+# PHP Composer
+RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');" \
+  && php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --quiet \
+  && rm -f /tmp/composer-setup.php
+
+ENV PHP_VERSION=7.0
+ENV COMPOSER_VENDOR_DIR=/home/site/wwwroot/vendor
+
 RUN chmod 755 /tmp/startup.sh
 	
 ENTRYPOINT [ "/tmp/startup.sh" ]

--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -219,8 +219,8 @@ RUN mkdir warmup \
     && rm -rf /tmp/NuGetScratch
 
 # PHP5.6
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends php5-cli
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends php5-cli
 
 # PHP7
 RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/stretch.list \

--- a/1.2/startup.sh
+++ b/1.2/startup.sh
@@ -10,6 +10,13 @@ USER_ID=$3
 USER_NAME=$4
 SITE_NAME=$5
 
+# PHP7 is the default PHP version, so change /usr/bin/ph* if PHP5 is specified
+if [[ "x$PHP_VERSION" =~ x5\.. && -x /usr/bin/php5 ]]; then
+  rm -f /etc/alternatives/php /etc/alternatives/phar
+  ln -s /usr/bin/php5 /etc/alternatives/php
+  ln -s /usr/bin/phar5 /etc/alternatives/phar
+fi
+
 groupadd -g $GROUP_ID $GROUP_NAME
 useradd -u $USER_ID -g $GROUP_NAME $USER_NAME
 chown -R $USER_NAME:$GROUP_NAME /etc/apache2

--- a/1.2/startup.sh
+++ b/1.2/startup.sh
@@ -17,6 +17,8 @@ if [[ "x$PHP_VERSION" =~ x5\.. && -x /usr/bin/php5 ]]; then
   ln -s /usr/bin/phar5 /etc/alternatives/phar
 fi
 
+[ -z $COMPOSER_ARGS ] && export COMPOSER_ARGS='--prefer-dist --no-dev --optimize-autoloader'
+
 groupadd -g $GROUP_ID $GROUP_NAME
 useradd -u $USER_ID -g $GROUP_NAME $USER_NAME
 chown -R $USER_NAME:$GROUP_NAME /etc/apache2


### PR DESCRIPTION
This change allows customers to run composer on their Kudu console. Currently only PHP5.6 and PHP7.0 are supported.