### PR TITLE
Fix for #9 by adding Node.js 6.9.3/NPM 3.10.10

### DIFF
--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -36,11 +36,13 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
   && wget -O /tmp/node-v6.2.2-linux-x64.tar.xz https://nodejs.org/dist/v6.2.2/node-v6.2.2-linux-x64.tar.xz \
   && wget -O /tmp/node-v6.6.0-linux-x64.tar.xz https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-x64.tar.xz \
   && wget -O /tmp/node-v6.9.1-linux-x64.tar.xz https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.xz \
+  && wget -O /tmp/node-v6.9.3-linux-x64.tar.xz https://nodejs.org/dist/v6.9.3/node-v6.9.3-linux-x64.tar.xz \
   && wget -O /tmp/npm-2.15.8.zip https://github.com/npm/npm/archive/v2.15.8.zip \
   && wget -O /tmp/npm-2.15.9.zip https://github.com/npm/npm/archive/v2.15.9.zip \
   && wget -O /tmp/npm-3.9.5.zip https://github.com/npm/npm/archive/v3.9.5.zip \
   && wget -O /tmp/npm-3.10.3.zip https://github.com/npm/npm/archive/v3.10.3.zip \
-  && wget -O /tmp/npm-3.10.8.zip https://github.com/npm/npm/archive/v3.10.8.zip 
+  && wget -O /tmp/npm-3.10.8.zip https://github.com/npm/npm/archive/v3.10.8.zip \
+  && wget -O /tmp/npm-3.10.10.zip https://github.com/npm/npm/archive/v3.10.10.zip 
 
 # Install npm and node
 RUN mkdir -p /opt/npm/2.15.8/node_modules \
@@ -68,6 +70,11 @@ RUN mkdir -p /opt/npm/2.15.8/node_modules \
   && mv /opt/npm/3.10.8/node_modules/npm-3.10.8 /opt/npm/3.10.8/node_modules/npm \
   && ln -s /opt/npm/3.10.8/node_modules/npm/bin/npm /opt/npm/3.10.8/npm \
   && chmod -R 755 /opt/npm/3.10.8/node_modules/npm/bin \
+  && mkdir -p /opt/npm/3.10.10/node_modules \
+  && unzip -q /tmp/npm-3.10.10.zip -d /opt/npm/3.10.10/node_modules \
+  && mv /opt/npm/3.10.10/node_modules/npm-3.10.10 /opt/npm/3.10.10/node_modules/npm \
+  && ln -s /opt/npm/3.10.10/node_modules/npm/bin/npm /opt/npm/3.10.10/npm \
+  && chmod -R 755 /opt/npm/3.10.10/node_modules/npm/bin \
   && chown -R root:root /opt/npm \
   && mkdir -p /opt/nodejs \
   && tar xfJ /tmp/node-v4.4.7-linux-x64.tar.xz -C /opt/nodejs \
@@ -91,19 +98,23 @@ RUN mkdir -p /opt/npm/2.15.8/node_modules \
   && rm -f node-v6.9.1-linux-x64.tar.xz \
   && mv /opt/nodejs/node-v6.9.1-linux-x64 /opt/nodejs/6.9.1 \
   && echo "3.10.8" > /opt/nodejs/6.9.1/npm.txt \
+  && tar xfJ /tmp/node-v6.9.3-linux-x64.tar.xz -C /opt/nodejs \
+  && rm -f node-v6.9.3-linux-x64.tar.xz \
+  && mv /opt/nodejs/node-v6.9.3-linux-x64 /opt/nodejs/6.9.3 \
+  && echo "3.10.10" > /opt/nodejs/6.9.3/npm.txt \
   && chown -R root:root /opt/nodejs \
-  && ln -s /opt/nodejs/6.9.1/bin/node /opt/nodejs/node \
-  && ln -s /opt/nodejs/6.9.1/npm.txt /opt/nodejs/npm.txt \
+  && ln -s /opt/nodejs/6.9.3/bin/node /opt/nodejs/node \
+  && ln -s /opt/nodejs/6.9.3/npm.txt /opt/nodejs/npm.txt \
   && rm -f /usr/bin/node \
-  && ln -s /opt/nodejs/6.9.1/bin/node /usr/bin/node \
-  && rm -f /opt/nodejs/6.9.1/bin/npm \
-  && ln -s /opt/npm/3.10.8/node_modules/npm/bin/npm /opt/nodejs/npm \
-  && ln -s /opt/npm/3.10.8/node_modules /opt/nodejs/node_modules \
+  && ln -s /opt/nodejs/6.9.3/bin/node /usr/bin/node \
+  && rm -f /opt/nodejs/6.9.3/bin/npm \
+  && ln -s /opt/npm/3.10.10/node_modules/npm/bin/npm /opt/nodejs/npm \
+  && ln -s /opt/npm/3.10.10/node_modules /opt/nodejs/node_modules \
   && rm -rf /usr/bin/npm \
-  && ln -s /opt/npm/3.10.8/node_modules/npm/bin/npm /usr/bin/npm \
-  && ln -s /opt/npm/3.10.8/node_modules /usr/bin/node_modules
+  && ln -s /opt/npm/3.10.10/node_modules/npm/bin/npm /usr/bin/npm \
+  && ln -s /opt/npm/3.10.10/node_modules /usr/bin/node_modules
   
-ENV PATH $PATH:/opt/nodejs/6.9.1/bin
+ENV PATH $PATH:/opt/nodejs/6.9.3/bin
 
 # Install Kudu
 RUN npm install -g kudusync \


### PR DESCRIPTION
This PR resolves #9 by ensuring the Node.js 6.9.3 and NPM 3.10.10 are downloaded, installed and set as the default Node.js versions for Kudu.