### PR TITLE
chmodding new starter.sh command wrapper

### DIFF
--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -121,6 +121,7 @@ RUN npm install -g kudusync \
   && mv /opt/Kudu/Web.config2 /opt/Kudu/Web.config \
   && chmod 755 /opt/Kudu/bin/kudu.exe \
   && chmod 755 /opt/Kudu/bin/node_modules/.bin/kuduscript \
+  && chmod -f 755 /opt/Kudu/bin/Scripts/starter.sh \
   && mkdir -p /opt/Kudu/local \
   && chmod 755 /opt/Kudu/local
 


### PR DESCRIPTION
starter.sh is a command wrapper used to execute custom deployment scripts and such. It doesn't do much but it's a parallel implementation to the Windows implementation, as part of a fix for a bug in the Linux code path.

It's -f because the file doesn't exist yet, but will in a new Kudu version.