### PR TITLE
Add PHP5 and 7.0

### DIFF
--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -234,6 +234,24 @@ RUN mkdir warmup \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch
 	
+# PHP5.6
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends php5-cli
+
+# PHP7
+RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/stretch.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends php7.0-cli php7.0-zip \
+  && rm -f /etc/apt/sources.list.d/stretch.list
+
+# PHP Composer
+RUN php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');" \
+  && php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --quiet \
+  && rm -f /tmp/composer-setup.php
+
+ENV PHP_VERSION=7.0
+ENV COMPOSER_VENDOR_DIR=/home/site/wwwroot/vendor
+
 RUN chmod 755 /tmp/startup.sh
 	
 ENTRYPOINT [ "/tmp/startup.sh" ]


### PR DESCRIPTION
I noticed that PHP5.6 and PHP7.0 which was already in Kudu 1.2 wasn't included in Kudu 1.3. Hence I am adding them to our latest version.