### PR TITLE
Add php extensions needed to run composer install

### DIFF
--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -248,7 +248,7 @@ RUN apt-get update \
 # PHP7
 RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/stretch.list \
   && apt-get update \
-  && apt-get install -y --no-install-recommends php7.0-cli php7.0-zip \
+  && apt-get install -y --no-install-recommends php7.0-cli php7.0-zip php7.0-mbstring php7.0-xml \
   && rm -f /etc/apt/sources.list.d/stretch.list
 
 # PHP Composer


### PR DESCRIPTION
In order to run composer install, php need to come with php-mbstring and php-xml configured.
The image in https://github.com/Benjiiim/kudu/tree/benjiiim_test_composer/1.3 can be built to try the change with the laravel default installation.