### PR TITLE
Node deployment fix

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -122,6 +122,7 @@ RUN mkdir -p /opt/npm/2.15.8/node_modules \
   && ln -s /opt/npm/3.10.10/node_modules /opt/nodejs/node_modules \
   && rm -rf /usr/bin/npm \
   && ln -s /opt/npm/3.10.10/node_modules/npm/bin/npm /usr/bin/npm \
+  && ln -s /opt/npm/3.10.10/node_modules/npm/bin/npm-cli.js /usr/bin/npm-cli.js \
   && ln -s /opt/npm/3.10.10/node_modules /usr/bin/node_modules
   
 ENV PATH $PATH:/opt/nodejs/6.10.2/bin


### PR DESCRIPTION
Symlinking npm-cli.js into /usr/bin. Kudu needs to be able to resolve an absolute path to this file (as opposed to npm, which i s a shell script wrapper) during node deployments.