### PR TITLE
Eliminating `chown /home`

### DIFF
--- a/1.5/startup.sh
+++ b/1.5/startup.sh
@@ -14,7 +14,6 @@ groupadd -g $GROUP_ID $GROUP_NAME
 useradd -u $USER_ID -g $GROUP_NAME $USER_NAME
 chown -R $USER_NAME:$GROUP_NAME /etc/apache2
 chown -R $USER_NAME:$GROUP_NAME /opt/Kudu
-chown -R $USER_NAME:$GROUP_NAME /home
 touch /var/log/apache2/kudu-error.log
 touch /var/log/apache2/kudu-access.log
 mkdir -p /var/lock/apache2 /var/run/apache2


### PR DESCRIPTION
`chown /home` takes so long to run on sites where deployments have already occurred to the site drive that it completely prevents the Kudu container from starting, and it does nothing anyway, as the drive permissions are controlled by the mount.