### PR TITLE
Start webssh with pm2 instead of node

### DIFF
--- a/kudu/Dockerfile
+++ b/kudu/Dockerfile
@@ -301,6 +301,11 @@ RUN npm install -g kudusync \
   && mkdir -p /opt/Kudu/local \
   && chmod 755 /opt/Kudu/local
 
+# Install pm2 and pm2-logrotate
+RUN npm install pm2@latest -g \
+  && pm2 install pm2-logrotate \
+  && pm2 set pm2-logrotate:retain 7
+
 # Install LogAnalyzer
 COPY LogAnalyzer.zip /tmp 
 RUN mkdir /opt/LogAnalyzer \ 

--- a/kudu/startup.sh
+++ b/kudu/startup.sh
@@ -30,7 +30,7 @@ cd /etc/apache2/sites-available
 a2dissite 000-default.conf
 a2ensite kudu.conf
 
-/bin/bash -c "node /opt/webssh/index.js &"
+/bin/bash -c "pm2 start /opt/webssh/index.js -o /home/LogFiles/webssh/pm2.log -e /home/LogFiles/webssh/pm2.err &"
 
 export KUDU_RUN_USER="$USER_NAME"
 export MONO_IOMAP=all


### PR DESCRIPTION
Start webssh with pm2 and pm2-logrotate instead of just node to make sure node process is auto restarted if it crashes.