### PR TITLE
node 10.1.0 should use npm 6.0.1

### DIFF
--- a/kudu/Dockerfile
+++ b/kudu/Dockerfile
@@ -171,6 +171,8 @@ RUN mkdir -p /opt/npm/2.15.8/node_modules \
   && rm -f node-v10.1.0-linux-x64.tar.xz \
   && mv /opt/nodejs/node-v10.1.0-linux-x64 /opt/nodejs/10.1.0 \
   && echo "6.0.1" > /opt/nodejs/10.1.0/npm.txt \
+  && rm /opt/nodejs/10.1.0/bin/npm \
+  && ln -s /opt/npm/6.0.1/npm /opt/nodejs/10.1.0/bin/npm \
   && chown -R root:root /opt/nodejs \
   && ln -s /opt/nodejs/6.11.0/bin/node /opt/nodejs/node \
   && ln -s /opt/nodejs/6.11.0/npm.txt /opt/nodejs/npm.txt \


### PR DESCRIPTION
node 10.1.0 comes with npm 5.6.0, we want npm 6.0.1